### PR TITLE
Implemented an `EpayeController` with an endpoint for `designatory-de…

### DIFF
--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/EpayeController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/EpayeController.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apprenticeshiplevy.controllers
+
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import uk.gov.hmrc.apprenticeshiplevy.data.epaye.{DesignatoryDetails, DesignatoryDetailsData, HodName}
+import uk.gov.hmrc.play.microservice.controller.BaseController
+
+object EpayeController extends EpayeController
+
+
+trait EpayeController extends BaseController {
+
+  import DesignatoryDetails._
+
+  def designatoryDetails(empref: String) = Action { implicit request =>
+    val details = DesignatoryDetails(Some(DesignatoryDetailsData(Some(HodName(Some("Foo Bar Ltd."), None)), None, None)), None)
+
+    Ok(Json.toJson(details))
+  }
+}

--- a/app/uk/gov/hmrc/apprenticeshiplevy/data/epaye/DesignatoryDetails.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/data/epaye/DesignatoryDetails.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apprenticeshiplevy.data.epaye
+
+import play.api.libs.json.Json
+
+case class HodName(nameLine1: Option[String] = None, nameLine2: Option[String] = None)
+
+case class HodTelephone(telephoneNumber: Option[String] = None, fax: Option[String] = None)
+
+case class HodEmail(primary: Option[String] = None)
+
+case class HodAddress(addressLine1: Option[String] = None,
+                      addressLine2: Option[String] = None,
+                      addressLine3: Option[String] = None,
+                      addressLine4: Option[String] = None,
+                      addressLine5: Option[String] = None,
+                      postcode: Option[String] = None,
+                      foreignCountry: Option[String] = None
+                     )
+
+case class HodContact(telephone: Option[HodTelephone] = None, email: Option[HodEmail] = None)
+
+case class DesignatoryDetailsData(name: Option[HodName] = None, address: Option[HodAddress] = None, contact: Option[HodContact] = None)
+
+case class DesignatoryDetails(employer: Option[DesignatoryDetailsData] = None, communication: Option[DesignatoryDetailsData] = None)
+
+object DesignatoryDetails {
+  implicit val hnformat = Json.format[HodName]
+  implicit val haformat = Json.format[HodAddress]
+  implicit val htformat = Json.format[HodTelephone]
+  implicit val heformat = Json.format[HodEmail]
+  implicit val hcformat = Json.format[HodContact]
+  implicit val dddformat = Json.format[DesignatoryDetailsData]
+
+  implicit val readDesignatoryDetailsFormat = Json.reads[DesignatoryDetails]
+  implicit val writeDesignatoryDetailsFormat = Json.writes[DesignatoryDetails]
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,3 +6,5 @@ GET        /empref/:empref/fractions                                          uk
 GET        /auth/authority                                                    uk.gov.hmrc.apprenticeshiplevy.controllers.AuthController.authority
 
 GET        /pay-as-you-earn/employers/:empref/charges/taxyear/:taxYear        uk.gov.hmrc.apprenticeshiplevy.controllers.ChargesController.charges(empref:String, taxYear:String)
+
+GET        /epaye/:empref/designatory-details                                 uk.gov.hmrc.apprenticeshiplevy.controllers.EpayeController.designatoryDetails(empref :String)


### PR DESCRIPTION
…tails` so that the levy api can include employer details in the response from the `/epaye/{empref}` endpoint