### PR TITLE
Updated to support changes to `declarations` and `fractions` endpoint parameters

### DIFF
--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/DateFiltering.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/DateFiltering.scala
@@ -16,18 +16,13 @@
 
 package uk.gov.hmrc.apprenticeshiplevy.controllers
 
-import play.api.libs.json.Json
-import play.api.mvc.Action
-import uk.gov.hmrc.apprenticeshiplevy.data.LevyData
-import uk.gov.hmrc.play.microservice.controller.BaseController
+import org.joda.time.LocalDate
 
-object LevyDeclarationController extends LevyDeclarationController
-
-trait LevyDeclarationController extends BaseController {
-  def declarations(empref: String, months: Option[Int]) = Action { implicit request =>
-    LevyData.data.get(empref) match {
-      case Some(ds) => Ok(Json.toJson(ds))
-      case None => NotFound
+trait DateFiltering {
+  implicit class DateFilterSyntax[T](eps: Seq[T])(implicit date: T => LocalDate) {
+    def filterDate(fromDate: Option[LocalDate], toDate: Option[LocalDate]): Seq[T] = {
+      val dateRange = DateRange(fromDate, toDate)
+      eps.filter(e => dateRange.contains(date(e)))
     }
   }
 }

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/DateRange.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/DateRange.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apprenticeshiplevy.controllers
+
+import org.joda.time.LocalDate
+
+sealed trait DateRange {
+  def contains(date: LocalDate): Boolean
+}
+
+case object OpenDateRange extends DateRange {
+  override def contains(date: LocalDate): Boolean = true
+}
+
+case class ClosedDateRange(from: LocalDate, to: LocalDate) extends DateRange {
+  override def contains(date: LocalDate): Boolean = !date.isBefore(from) && !date.isAfter(to)
+}
+
+case class OpenEarlyDateRange(to: LocalDate) extends DateRange {
+  override def contains(date: LocalDate): Boolean = !date.isAfter(to)
+}
+
+case class OpenLateDateRange(from: LocalDate) extends DateRange {
+  override def contains(date: LocalDate): Boolean = !date.isBefore(from)
+}
+
+object DateRange {
+  def apply(fromDate: Option[LocalDate], toDate: Option[LocalDate]): DateRange = {
+    (fromDate, toDate) match {
+      case (None, None) => OpenDateRange
+      case (Some(from), Some(to)) => ClosedDateRange(from, to)
+      case (None, Some(to)) => OpenEarlyDateRange(to)
+      case (Some(from), None) => OpenLateDateRange(from)
+    }
+  }
+}

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionController.scala
@@ -19,15 +19,25 @@ package uk.gov.hmrc.apprenticeshiplevy.controllers
 import org.joda.time.LocalDate
 import play.api.libs.json.Json
 import play.api.mvc.Action
-import uk.gov.hmrc.apprenticeshiplevy.data.FractionData
+import uk.gov.hmrc.apprenticeshiplevy.data.{FractionCalculation, FractionData, Fractions}
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 object FractionController extends FractionController
 
 trait FractionController extends BaseController {
-  def fractions(empref: String, months: Option[Int]) = Action { implicit request =>
+
+  implicit class DateFilterSyntax(fractions: Seq[FractionCalculation]) {
+    def filterDate(fromDate: Option[LocalDate], toDate: Option[LocalDate]): Seq[FractionCalculation] = {
+      val dateRange = DateRange(fromDate, toDate)
+      fractions.filter(f => dateRange.contains(f.calculatedAt))
+    }
+  }
+
+  def fractions(empref: String, fromDate: Option[LocalDate], toDate: Option[LocalDate]) = Action { implicit request =>
     FractionData.data.get(empref) match {
-      case Some(ds) => Ok(Json.toJson(ds))
+      case Some(fractions) =>
+        val filtered = fractions.fractionCalculations.filterDate(fromDate, toDate).toList
+        Ok(Json.toJson(fractions.copy(fractionCalculations = filtered)))
       case None => NotFound
     }
   }

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionController.scala
@@ -24,16 +24,10 @@ import uk.gov.hmrc.play.microservice.controller.BaseController
 
 object FractionController extends FractionController
 
-trait FractionController extends BaseController {
-
-  implicit class DateFilterSyntax(fractions: Seq[FractionCalculation]) {
-    def filterDate(fromDate: Option[LocalDate], toDate: Option[LocalDate]): Seq[FractionCalculation] = {
-      val dateRange = DateRange(fromDate, toDate)
-      fractions.filter(f => dateRange.contains(f.calculatedAt))
-    }
-  }
-
+trait FractionController extends BaseController with DateFiltering {
   def fractions(empref: String, fromDate: Option[LocalDate], toDate: Option[LocalDate]) = Action { implicit request =>
+    implicit val dateExtractor = (f: FractionCalculation) => f.calculatedAt
+
     FractionData.data.get(empref) match {
       case Some(fractions) =>
         val filtered = fractions.fractionCalculations.filterDate(fromDate, toDate).toList

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/RtiController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/RtiController.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.apprenticeshiplevy.controllers
 
+import org.joda.time.LocalDate
 import play.api.libs.json.Json
 import play.api.mvc.Action
 import uk.gov.hmrc.apprenticeshiplevy.data.RtiData
@@ -23,7 +24,7 @@ import uk.gov.hmrc.play.microservice.controller.BaseController
 
 trait RtiController extends BaseController {
 
-  def eps(empref: String, months: Option[Int]) = Action { implicit request =>
+  def eps(empref: String, fromDate: Option[LocalDate], toDate: Option[LocalDate]) = Action { implicit request =>
     RtiData.data.get(empref) match {
       case Some(eps) => Ok(Json.toJson(eps))
       case _ => NotFound

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/RtiController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/RtiController.scala
@@ -23,16 +23,9 @@ import uk.gov.hmrc.apprenticeshiplevy.data.{EmployerPaymentSummary, RtiData}
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 
-trait RtiController extends BaseController {
-
-  implicit class DateFilterSyntax(eps: Seq[EmployerPaymentSummary]) {
-    def filterDate(fromDate: Option[LocalDate], toDate: Option[LocalDate]): Seq[EmployerPaymentSummary] = {
-      val dateRange = DateRange(fromDate, toDate)
-      eps.filter(e => dateRange.contains(e.submissionTime.toLocalDate))
-    }
-  }
-
+trait RtiController extends BaseController with DateFiltering {
   def eps(empref: String, fromDate: Option[LocalDate], toDate: Option[LocalDate]) = Action { implicit request =>
+    implicit val dateExtractor = (e: EmployerPaymentSummary) => e.submissionTime.toLocalDate
     RtiData.data.get(empref) match {
       case Some(eps) => Ok(Json.toJson(eps.filterDate(fromDate, toDate)))
       case _ => NotFound

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/RtiController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/RtiController.scala
@@ -19,14 +19,22 @@ package uk.gov.hmrc.apprenticeshiplevy.controllers
 import org.joda.time.LocalDate
 import play.api.libs.json.Json
 import play.api.mvc.Action
-import uk.gov.hmrc.apprenticeshiplevy.data.RtiData
+import uk.gov.hmrc.apprenticeshiplevy.data.{EmployerPaymentSummary, RtiData}
 import uk.gov.hmrc.play.microservice.controller.BaseController
+
 
 trait RtiController extends BaseController {
 
+  implicit class DateFilterSyntax(eps: Seq[EmployerPaymentSummary]) {
+    def filterDate(fromDate: Option[LocalDate], toDate: Option[LocalDate]): Seq[EmployerPaymentSummary] = {
+      val dateRange = DateRange(fromDate, toDate)
+      eps.filter(e => dateRange.contains(e.submissionTime.toLocalDate))
+    }
+  }
+
   def eps(empref: String, fromDate: Option[LocalDate], toDate: Option[LocalDate]) = Action { implicit request =>
     RtiData.data.get(empref) match {
-      case Some(eps) => Ok(Json.toJson(eps))
+      case Some(eps) => Ok(Json.toJson(eps.filterDate(fromDate, toDate)))
       case _ => NotFound
     }
   }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,5 +1,4 @@
 
-GET        /empref/:empref/declarations                                       uk.gov.hmrc.apprenticeshiplevy.controllers.LevyDeclarationController.declarations(empref: String, months: Option[Int])
 GET        /empref/:empref/employee/:nino                                     uk.gov.hmrc.apprenticeshiplevy.controllers.EmploymentCheckController.check(empref: String, nino: String, atDate: Option[LocalDate])
 GET        /empref/:empref/fractions                                          uk.gov.hmrc.apprenticeshiplevy.controllers.FractionController.fractions(empref: String, fromDate: Option[LocalDate], toDate: Option[LocalDate])
 GET        /fraction-calculation-date                                         uk.gov.hmrc.apprenticeshiplevy.controllers.FractionController.fractionCalculationDate

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -10,4 +10,4 @@ GET        /pay-as-you-earn/employers/:empref/charges/taxyear/:taxYear        uk
 
 GET        /epaye/:empref/designatory-details                                 uk.gov.hmrc.apprenticeshiplevy.controllers.EpayeController.designatoryDetails(empref: String)
 
-GET        /epaye/:empref/eps                                                 uk.gov.hmrc.apprenticeshiplevy.controllers.RtiController.eps(empref: String, months: Option[Int])
+GET        /epaye/:empref/eps                                                 uk.gov.hmrc.apprenticeshiplevy.controllers.RtiController.eps(empref: String, fromDate: Option[LocalDate], toDate: Option[LocalDate])

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,7 @@
 
 GET        /empref/:empref/declarations                                       uk.gov.hmrc.apprenticeshiplevy.controllers.LevyDeclarationController.declarations(empref: String, months: Option[Int])
 GET        /empref/:empref/employee/:nino                                     uk.gov.hmrc.apprenticeshiplevy.controllers.EmploymentCheckController.check(empref: String, nino: String, atDate: Option[LocalDate])
-GET        /empref/:empref/fractions                                          uk.gov.hmrc.apprenticeshiplevy.controllers.FractionController.fractions(empref: String, months: Option[Int])
+GET        /empref/:empref/fractions                                          uk.gov.hmrc.apprenticeshiplevy.controllers.FractionController.fractions(empref: String, fromDate: Option[LocalDate], toDate: Option[LocalDate])
 GET        /fraction-calculation-date                                         uk.gov.hmrc.apprenticeshiplevy.controllers.FractionController.fractionCalculationDate
 
 GET        /auth/authority                                                    uk.gov.hmrc.apprenticeshiplevy.controllers.AuthController.authority

--- a/test/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionControllerSpec.scala
+++ b/test/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionControllerSpec.scala
@@ -23,7 +23,7 @@ import play.api.test.FakeRequest
 class FractionControllerSpec extends FlatSpec with Matchers with ScalaFutures {
 
   "GET /fractions" should "return 200" in {
-    FractionController.fractions("123/AB12345", None)(FakeRequest()).futureValue.header.status shouldBe 200
+    FractionController.fractions("123/AB12345", None, None)(FakeRequest()).futureValue.header.status shouldBe 200
   }
 
 }

--- a/test/uk/gov/hmrc/apprenticeshiplevy/controllers/RtiControllerSpec.scala
+++ b/test/uk/gov/hmrc/apprenticeshiplevy/controllers/RtiControllerSpec.scala
@@ -20,10 +20,10 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.test.FakeRequest
 
-class LevyDeclarationControllerSpec extends FlatSpec with Matchers with ScalaFutures {
+class RtiControllerSpec extends FlatSpec with Matchers with ScalaFutures {
 
   "declarations" should "return 200" in {
-    LevyDeclarationController.declarations("123/AB12345", None)(FakeRequest()).futureValue.header.status shouldBe 200
+    RtiController.eps("123/AB12345", None, None)(FakeRequest()).futureValue.header.status shouldBe 200
   }
 
 }


### PR DESCRIPTION
I've updated the corresponding stub endpoints to use `fromDate` and `toDate` parameters rather than `months`. This better reflects the APIs we've agreed with Capgemini in any case.